### PR TITLE
Test shelljs versions

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-require('shelljs/global');
-
 var TEST_DIR = 'scripts';
 
 var shouldLog = (process.argv[2] === 'log');
@@ -14,71 +12,76 @@ function writeLog(msg, link) {
   log.push(msg);
 }
 
-cd(__dirname + '/' + TEST_DIR);
-var prefix;
-var shellJSWins = [];
-ls().forEach(function (dir) {
-  prefix = TEST_DIR + '/' + dir;
-  writeLog('### [' + dir + ']', prefix)
-  cd(dir)
+require('fs').readdirSync('shelljs').forEach(function (version) {
+  console.log('Testing ShellJS version ' + version);
+  require('./shelljs/' + version);
+  cd(__dirname + '/' + TEST_DIR);
+  var prefix;
+  var shellJSWins = [];
+  ls().forEach(function (dir) {
+    prefix = TEST_DIR + '/' + dir;
+    writeLog('### [' + dir + ']', prefix)
+    cd(dir)
 
-  // Find the files
-  var jsfile = ls('*.js')[0];
-  var shfile = ls('*.sh')[0];
+    // Find the files
+    var jsfile = ls('*.js')[0];
+    var shfile = ls('*.sh')[0];
 
-  if (!jsfile || !shfile) {
-    console.error('Could not find your files. Please use proper extensions.');
-    return;
+    if (!jsfile || !shfile) {
+      console.error('Could not find your files. Please use proper extensions.');
+      return;
+    }
+
+    // execute it
+    var start_time,
+        end_time,
+        shell_time,
+        shell_output,
+        js_time,
+        js_output;
+
+    config.silent = true;
+
+    start_time = new Date().getTime();
+    js_output = exec('node ' + jsfile).output;
+    end_time = new Date().getTime();
+    js_time = end_time - start_time;
+    writeLog(' - [ShellJS] took `' + js_time + '` milliseconds', prefix + '/' + jsfile);
+
+    start_time = new Date().getTime();
+    shell_output = exec('bash ' + shfile).output;
+    end_time = new Date().getTime();
+    shell_time = end_time - start_time;
+    writeLog(' - [Bash] took `' + shell_time + '` milliseconds', prefix + '/' + shfile);
+
+    if (shell_time < js_time) {
+      writeLog('Bash was `' + (js_time/shell_time).toFixed(3) + '` times faster than ShellJS');
+    } else {
+      writeLog('ShellJS was `' + (shell_time/js_time).toFixed(3) + '` times faster than Bash');
+      shellJSWins.push(dir);
+    }
+
+    if (shell_output !== js_output)
+      writeLog('Output differs');
+
+    // Clean up
+    echo('=======================');
+    echo();
+    config.silent = false;
+    cd('..')
+  });
+
+  if (shouldLog) {
+    cd(__dirname);
+    var text = '### ShellJS performance wins\n\n';
+    text += shellJSWins.map(x => ' - [' + x + '](' + TEST_DIR + '/' + x + ')').join('\n');
+    text += '\n\n' + log.join('\n\n');
+
+    // Wipe out the old results
+    cat('README.md').replace(/## Results(.|\n)*/, '## Results').to('README.md');
+
+    // Append new docs to README
+    sed('-i', /## Results/, '## Results\n\n' + text, 'README.md');
   }
-
-  // execute it
-  var start_time,
-      end_time,
-      shell_time,
-      shell_output,
-      js_time,
-      js_output;
-
-  config.silent = true;
-
-  start_time = new Date().getTime();
-  js_output = exec('node ' + jsfile).output;
-  end_time = new Date().getTime();
-  js_time = end_time - start_time;
-  writeLog(' - [ShellJS] took `' + js_time + '` milliseconds', prefix + '/' + jsfile);
-
-  start_time = new Date().getTime();
-  shell_output = exec('bash ' + shfile).output;
-  end_time = new Date().getTime();
-  shell_time = end_time - start_time;
-  writeLog(' - [Bash] took `' + shell_time + '` milliseconds', prefix + '/' + shfile);
-
-  if (shell_time < js_time) {
-    writeLog('Bash was `' + (js_time/shell_time).toFixed(3) + '` times faster than ShellJS');
-  } else {
-    writeLog('ShellJS was `' + (shell_time/js_time).toFixed(3) + '` times faster than Bash');
-    shellJSWins.push(dir);
-  }
-
-  if (shell_output !== js_output)
-    writeLog('Output differs');
-
-  // Clean up
-  echo('=======================');
-  echo();
-  config.silent = false;
-  cd('..')
-});
-
-if (shouldLog) {
   cd(__dirname);
-  var text = '### ShellJS performance wins\n\n';
-  text += shellJSWins.map(x => ' - [' + x + '](' + TEST_DIR + '/' + x + ')').join('\n');
-  text += '\n\n' + log.join('\n\n');
-
-  // Wipe out the old results
-  cat('README.md').replace(/## Results(.|\n)*/, '## Results').to('README.md');
-
-  // Append new docs to README
-  sed('-i', /## Results/, '## Results\n\n' + text, 'README.md');
-}
+});

--- a/install
+++ b/install
@@ -1,0 +1,9 @@
+#!/bin/sh
+cd shelljs
+for D in *
+do
+  cd "$D"
+  npm install
+  cd ..
+done
+cd ..

--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
   "homepage": "https://github.com/IvantheDugtrio/ShellJSBench#readme",
   "bin": {
     "benchmark": "./benchmark.js"
-  },
-  "dependencies": {
-    "shelljs": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Benchmark ShellJS scripts",
   "main": "index.js",
   "scripts": {
+    "install": "./install",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/shelljs/0.5.3/.gitignore
+++ b/shelljs/0.5.3/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/shelljs/0.5.3/index.js
+++ b/shelljs/0.5.3/index.js
@@ -1,0 +1,1 @@
+module.exports = require('shelljs');

--- a/shelljs/0.5.3/index.js
+++ b/shelljs/0.5.3/index.js
@@ -1,1 +1,1 @@
-module.exports = require('shelljs');
+module.exports = require('shelljs/global');

--- a/shelljs/0.5.3/package.json
+++ b/shelljs/0.5.3/package.json
@@ -5,5 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "shelljs": "^0.5.3"
-  }
+  },
+  "repository": {},
+  "license": "ISC"
 }

--- a/shelljs/0.5.3/package.json
+++ b/shelljs/0.5.3/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "shelljs-0.5.3",
+  "version": "1.0.0",
+  "description": "ShellJS v0.5.3",
+  "main": "index.js",
+  "dependencies": {
+    "shelljs": "^0.5.3"
+  }
+}

--- a/shelljs/0.6.0/.gitignore
+++ b/shelljs/0.6.0/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/shelljs/0.6.0/index.js
+++ b/shelljs/0.6.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('shelljs');

--- a/shelljs/0.6.0/index.js
+++ b/shelljs/0.6.0/index.js
@@ -1,1 +1,1 @@
-module.exports = require('shelljs');
+module.exports = require('shelljs/global');

--- a/shelljs/0.6.0/package.json
+++ b/shelljs/0.6.0/package.json
@@ -5,5 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "shelljs": "^0.6.0"
-  }
+  },
+  "repository": {},
+  "license": "ISC"
 }

--- a/shelljs/0.6.0/package.json
+++ b/shelljs/0.6.0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "shelljs-0.6.0",
+  "version": "1.0.0",
+  "description": "ShellJS v0.6.0",
+  "main": "index.js",
+  "dependencies": {
+    "shelljs": "^0.6.0"
+  }
+}


### PR DESCRIPTION
Fixes #2.
- Adds a `shelljs/` directory that contains packages for various versions of ShellJS (so, 0.5.3 and 0.6.0), and an `install` script that installs those versions: `$ npm install`
- Modifies `benchmark.js` to test all of the versions of ShellJS in `shelljs/` sequentially
