### PR TITLE
Print system information after tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# ShellJSBench
+# ShellJS Benchmarks
+
 Collection of benchmarks for ShellJS
 
-These benchmarks aim to compare shelljs performance to that of bash, sh, and zsh.
-It works by running shell utilities and timing the speed of completion for each 
-tested utility.
-
-This will comprise every shell utility ShellJS supports.
+This is a comparison of [ShellJS]() and bash for performance. Each test case
+runs scripts with equivalent output and compares Bash's runtime with ShellJS's.
+Surprisingly, ShellJS is often the winner, sometimes being up to **12x faster**!
+Woohoo! See below for [ShellJS performance wins](#shelljs-performance-wins).
 
 ## Results
 
@@ -16,66 +16,96 @@ This will comprise every shell utility ShellJS supports.
  - [ls10k](scripts/ls10k)
  - [touchSyntax06](scripts/touchSyntax06)
 
+## System Information:
+
+ - Linux
+
+ - 4.2.0-30-generic
+
+ - x64
+
+ - Intel(R) Core(TM) i5-3317U CPU @ 1.70GHz x 4
+
+## Node information
+
+ - Node.js v5.3.0
+
+ - V8 4.6.85.31
+
+
+
+## Shell Information:
+
+ - /bin/bash
+
+
+ - GNU bash, version 4.3.42(1)-release (x86_64-pc-linux-gnu)
+Copyright (C) 2013 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software; you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+
 ### [echoIntoFile](scripts/echoIntoFile)
 
- - [ShellJS](scripts/echoIntoFile/echoIntoFile.js) took `199` milliseconds
+ - [ShellJS](scripts/echoIntoFile/echoIntoFile.js) took `257` milliseconds
 
- - [Bash](scripts/echoIntoFile/echoIntoFile.sh) took `430` milliseconds
+ - [Bash](scripts/echoIntoFile/echoIntoFile.sh) took `832` milliseconds
 
-ShellJS was `2.161` times faster than Bash
+ShellJS was `3.237` times faster than Bash
 
 ### [envVariable](scripts/envVariable)
 
- - [ShellJS](scripts/envVariable/envVar.js) took `723` milliseconds
+ - [ShellJS](scripts/envVariable/envVar.js) took `1164` milliseconds
 
- - [Bash](scripts/envVariable/envVar.sh) took `723` milliseconds
+ - [Bash](scripts/envVariable/envVar.sh) took `1451` milliseconds
 
-ShellJS was `1.000` times faster than Bash
+ShellJS was `1.247` times faster than Bash
 
 ### [forLoopAlternateSyntax](scripts/forLoopAlternateSyntax)
 
- - [ShellJS](scripts/forLoopAlternateSyntax/helloworld10k.js) took `112` milliseconds
+ - [ShellJS](scripts/forLoopAlternateSyntax/helloworld10k.js) took `184` milliseconds
 
- - [Bash](scripts/forLoopAlternateSyntax/helloworld10k.sh) took `76` milliseconds
+ - [Bash](scripts/forLoopAlternateSyntax/helloworld10k.sh) took `92` milliseconds
 
-Bash was `1.474` times faster than ShellJS
+Bash was `2.000` times faster than ShellJS
 
 ### [helloworld](scripts/helloworld)
 
- - [ShellJS](scripts/helloworld/helloworld.js) took `110` milliseconds
+ - [ShellJS](scripts/helloworld/helloworld.js) took `178` milliseconds
 
- - [Bash](scripts/helloworld/helloworld.sh) took `60` milliseconds
+ - [Bash](scripts/helloworld/helloworld.sh) took `83` milliseconds
 
-Bash was `1.833` times faster than ShellJS
+Bash was `2.145` times faster than ShellJS
 
 ### [helloworld10k](scripts/helloworld10k)
 
- - [ShellJS](scripts/helloworld10k/helloworld10k.js) took `170` milliseconds
+ - [ShellJS](scripts/helloworld10k/helloworld10k.js) took `288` milliseconds
 
- - [Bash](scripts/helloworld10k/helloworld10k.sh) took `94` milliseconds
+ - [Bash](scripts/helloworld10k/helloworld10k.sh) took `217` milliseconds
 
-Bash was `1.809` times faster than ShellJS
+Bash was `1.327` times faster than ShellJS
 
 ### [ls10k](scripts/ls10k)
 
- - [ShellJS](scripts/ls10k/ls10k.js) took `447` milliseconds
+ - [ShellJS](scripts/ls10k/ls10k.js) took `743` milliseconds
 
- - [Bash](scripts/ls10k/ls10k.sh) took `3714` milliseconds
+ - [Bash](scripts/ls10k/ls10k.sh) took `10145` milliseconds
 
-ShellJS was `8.309` times faster than Bash
+ShellJS was `13.654` times faster than Bash
 
 ### [pwd10k](scripts/pwd10k)
 
- - [ShellJS](scripts/pwd10k/path10k.js) took `1103` milliseconds
+ - [ShellJS](scripts/pwd10k/path10k.js) took `2039` milliseconds
 
- - [Bash](scripts/pwd10k/path10k.sh) took `329` milliseconds
+ - [Bash](scripts/pwd10k/path10k.sh) took `740` milliseconds
 
-Bash was `3.353` times faster than ShellJS
+Bash was `2.755` times faster than ShellJS
 
 ### [touchSyntax06](scripts/touchSyntax06)
 
- - [ShellJS](scripts/touchSyntax06/touchrm10k.js) took `172` milliseconds
+ - [ShellJS](scripts/touchSyntax06/touchrm10k.js) took `322` milliseconds
 
- - [Bash](scripts/touchSyntax06/touchrm10k.sh) took `730` milliseconds
+ - [Bash](scripts/touchSyntax06/touchrm10k.sh) took `1565` milliseconds
 
-ShellJS was `4.244` times faster than Bash
+ShellJS was `4.860` times faster than Bash

--- a/benchmark.js
+++ b/benchmark.js
@@ -7,6 +7,8 @@ var shouldLog = (process.argv[2] === 'log');
 var log = [];
 
 function writeLog(msg, link) {
+  if (!msg)
+    msg = '';
   console.log(msg);
   if (link) {
     msg = msg.replace(']', '](' + link + ')');
@@ -16,21 +18,39 @@ function writeLog(msg, link) {
 
 function printSystemInfo() {
   var os = require('os');
-  var cpus = os.cpus();
-  var spawn = require('child_process').spawn;
-  console.log('System Information:');
-  console.log(os.type(), os.release(), os.arch());
-  console.log('Node.js ' + process.versions.node);
-  console.log('V8 ' + process.versions.v8);
-  console.log(cpus[0].model + ' × ' + cpus.length);
-  console.log();
-  console.log('Shell Information:');
-  spawn('sh', ['-c', '${SHELL} --version'], { stdio: 'inherit' });
+  var cpuInfo = os.cpus().reduce(function (cpus, cur) {
+    var idx = 0;
+    cpus.forEach(function (thisCpu) {
+      if (thisCpu.model === cur.name) return;
+      idx++;
+    });
+    if (idx !== cpus.length)
+      cpus[idx].count++;
+    else
+      cpus.push({name: cur.model, count: 1});
+    return cpus;
+  }, []);
+  writeLog('## System Information:');
+  writeLog(' - ' + os.type());
+  writeLog(' - ' + os.release());
+  writeLog(' - ' + os.arch());
+  cpuInfo.forEach(function (cpu) {
+    writeLog(' - ' + cpu.name + ' × ' + cpu.count);
+  });
+  writeLog('## Node information');
+  writeLog(' - Node.js: ' + exec('node -v').stdout.trim());
+  writeLog(' - V8: ' + process.versions.v8);
+  writeLog();
+  writeLog('## Shell Information:');
+  writeLog(' - name: `' + exec('bash -c \'echo ${SHELL}\'', {silent: true}).stdout + '`');
+  writeLog(' - version: ' + exec('bash --version', {silent: true}).stdout.replace(/\n+/g, '\n'));
 }
 
 cd(__dirname + '/' + TEST_DIR);
 var prefix;
 var shellJSWins = [];
+printSystemInfo();
+
 ls().forEach(function (dir) {
   prefix = TEST_DIR + '/' + dir;
   writeLog('### [' + dir + ']', prefix)
@@ -96,4 +116,3 @@ if (shouldLog) {
   // Append new docs to README
   sed('-i', /## Results/, '## Results\n\n' + text, 'README.md');
 }
-printSystemInfo();

--- a/benchmark.js
+++ b/benchmark.js
@@ -14,6 +14,20 @@ function writeLog(msg, link) {
   log.push(msg);
 }
 
+function printSystemInfo() {
+  var os = require('os');
+  var cpus = os.cpus();
+  var spawn = require('child_process').spawn;
+  console.log('System Information:');
+  console.log(os.type(), os.release(), os.arch());
+  console.log('Node.js ' + process.versions.node);
+  console.log('V8 ' + process.versions.v8);
+  console.log(cpus[0].model + ' × ' + cpus.length);
+  console.log();
+  console.log('Shell Information:');
+  spawn('sh', ['-c', '${SHELL} --version'], { stdio: 'inherit' });
+}
+
 cd(__dirname + '/' + TEST_DIR);
 var prefix;
 var shellJSWins = [];
@@ -82,3 +96,4 @@ if (shouldLog) {
   // Append new docs to README
   sed('-i', /## Results/, '## Results\n\n' + text, 'README.md');
 }
+printSystemInfo();


### PR DESCRIPTION
Adds system information logging after tests. See #3.

For example:

```
System Information:
Darwin 15.3.0 x64
Node.js 5.7.0
V8 4.6.85.31
Intel(R) Core(TM) i7-4558U CPU @ 2.80GHz × 4

Shell Information:
GNU bash, version 4.3.42(1)-release (x86_64-apple-darwin14.5.0)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```
